### PR TITLE
Fixed hiera example, added precision and plugin_type for hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,19 @@ telegraf::inputs:
   cpu:
     - percpu: true
       totalcpu: true
-  mem: []
-  io: []
-  net: []
-  disk: []
-  swap: []
-  system: []
+  exec:
+    - commands:
+        - who | wc -l
+  exec-uptime:
+    - commands:
+        - cat /proc/uptime | awk '{print $1}'
+      plugin_type: exec
+  mem: [{}]
+  io: [{}]
+  net: [{}]
+  disk: [{}]
+  swap: [{}]
+  system: [{}]
 telegraf::outputs:
   influxdb:
     - urls:
@@ -230,10 +237,10 @@ telegraf::inputs:
   cpu:
     - percpu: true
       totalcpu: true
-  mem: []
-  io: []
-  net: []
-  disk: []
+  mem: [{}]
+  io: [{}]
+  net: [{}]
+  disk: [{}]
 ```
 
 Specific roles will include some extra plugins, e.g. `role/frontend.yaml`:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ class telegraf (
   $collection_jitter      = $telegraf::params::collection_jitter,
   $flush_interval         = $telegraf::params::flush_interval,
   $flush_jitter           = $telegraf::params::flush_jitter,
+  $precision              = $telegraf::params::precision,
   $logfile                = $telegraf::params::logfile,
   $debug                  = $telegraf::params::debug,
   $quiet                  = $telegraf::params::quiet,
@@ -138,6 +139,7 @@ class telegraf (
   validate_string($collection_jitter)
   validate_string($flush_interval)
   validate_string($flush_jitter)
+  validate_string($precision)
   validate_bool($debug)
   validate_bool($quiet)
   validate_hash($inputs)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class telegraf::params {
   $collection_jitter      = '0s'
   $flush_interval         = '10s'
   $flush_jitter           = '0s'
+  $precision              = ''
   $debug                  = false
   $quiet                  = false
   $global_tags            = {}

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -36,14 +36,21 @@ describe 'telegraf' do
                 "disk" => [{
                   "ignore_fs" => ['tmpfs','devtmpfs'],
                 }],
-                "diskio"      => [],
-                "kernel"      => [],
-                "mem"         => [],
+                "diskio"      => [{}],
+                "kernel"      => [{}],
+                "exec"        => [{
+                  "commands" => ['who | wc -l'],
+                }],
+                "exec-uptime" => [{
+                  "commands"    => ["cat /proc/uptime | awk '{print $1}'"],
+                  "plugin_type" => 'exec',
+                }],
+                "mem"         => [{}],
                 "net"         => [{
                   "interfaces" => ['eth0'],
                   "drop"       => ['net_icmp'],
                 }],
-                "netstat"     => [],
+                "netstat"     => [{}],
                 "ping"        => [{
                   "urls"    => ['10.10.10.1'],
                   "count"   => 1,
@@ -61,8 +68,8 @@ describe 'telegraf' do
                   "percentile_limit"         => 1000,
                   "udp_packet_size"          => 1500,
                 }],
-                "swap"        => [],
-                "system"      => [],
+                "swap"        => [{}],
+                "system"      => [{}],
               }],
               :outputs        => [{
                 "influxdb" => [{

--- a/spec/hieradata/test/telegraf.yaml
+++ b/spec/hieradata/test/telegraf.yaml
@@ -16,15 +16,22 @@ telegraf::inputs:
     - ignore_fs:
         - "tmpfs"
         - "devtmpfs"
-  diskio: []
-  kernel: []
-  mem: []
+  diskio: [{}]
+  kernel: [{}]
+  exec:
+    - commands:
+        - who | wc -l
+  exec-uptime:
+    - commands:
+        - cat /proc/uptime | awk '{print $1}'
+      plugin_type: exec
+  mem: [{}]
   net:
     - interfaces:
         - "eth0"
       drop:
         - "net_icmp"
-  netstat: []
+  netstat: [{}]
   ping:
     - urls:
         - "10.10.10.1"
@@ -42,8 +49,8 @@ telegraf::inputs:
       allowed_pending_messages: 10000
       percentile_limit: 1000
       udp_packet_size: 1500
-  swap: []
-  system: []
+  swap: [{}]
+  system: [{}]
 telegraf::outputs:
   influxdb:
     - urls:

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -19,6 +19,7 @@
   collection_jitter = "<%= @collection_jitter %>"
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"
+  precision = "<%= @precision %>"
   logfile = "<%= @logfile %>"
   debug = <%= @debug %>
   quiet = <%= @quiet %>
@@ -27,12 +28,38 @@
 #
 # OUTPUTS:
 #
-<%= require 'toml-rb'; TomlRB.dump({'outputs'=>@_outputs}) %>
+<% require 'toml-rb'
+
+@_outputs.sort.each do |key, values|
+  @new_values = {}
+  values[0].each do |k, v|
+    if k == 'plugin_type' then
+      key = v
+    else
+      @new_values[k] = v
+    end
+  end
+  @new_output = {key=>Array.new().push(@new_values)} -%>
+<%= TomlRB.dump({'outputs'=>@new_output}) %>
+<% end -%>
 <% end -%>
 
 <% if @_inputs -%>
 #
 # INPUTS:
 #
-<%= require 'toml-rb'; TomlRB.dump({'inputs'=>@_inputs}) %>
+<% require 'toml-rb'
+
+@_inputs.sort.each do |key, values|
+  @new_values = {}
+  values[0].each do |k, v|
+    if k == 'plugin_type' then
+      key = v
+    else
+      @new_values[k] = v
+    end
+  end
+  @new_input = {key=>Array.new().push(@new_values)} -%>
+<%= TomlRB.dump({'inputs'=>@new_input}) %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
We need to be able to specify multiple inputs and outputs of the same type from hiera.  This PR adds that in as well as the precision property and fixes some of the spec tests (hopefully).  I'm not a Ruby guy either.